### PR TITLE
Activate backtraces in child processes by default

### DIFF
--- a/lib/core/release.ml
+++ b/lib/core/release.ml
@@ -185,7 +185,8 @@ let getenv k =
 let restrict_env allowed =
   let setenv env k =
     Option.may_default env (fun v -> v::env) (getenv k) in
-  Array.of_list (List.fold_left setenv ["PATH=/bin:/usr/bin"] allowed)
+  Array.of_list (List.fold_left setenv
+    ["PATH=/bin:/usr/bin"; "OCAMLRUNPARAM=b"] allowed)
 
 let rec exec_process cmd ipc_handler slave_env check_death_rate =
   lwt () = check_death_rate () in


### PR DESCRIPTION
I'm not sure this is the right thing to do, but it did help me quite a bit when tracking down exceptions in the child (such as ocsigen/lwt#23).

However it might block other OCAMLRUNPARAM uses such as GC settings...
